### PR TITLE
Fix to return errors for vm.create and vm.delete

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -6,12 +6,13 @@
 	],
 	"Deps": [
 		{
-			"ImportPath": "github.com/kolo/xmlrpc",
-			"Rev": "0826b98aaa29c0766956cb40d45cf7482a597671"
+			"ImportPath": "github.com/Sirupsen/logrus",
+			"Comment": "v0.8.7",
+			"Rev": "418b41d23a1bf978c06faea5313ba194650ac088"
 		},
 		{
-			"ImportPath": "gopkg.in/check.v1",
-			"Rev": "11d3bc7aa68e238947792f30573146a3231fc0f1"
+			"ImportPath": "github.com/kolo/xmlrpc",
+			"Rev": "0826b98aaa29c0766956cb40d45cf7482a597671"
 		}
 	]
 }

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ bzr:
 	$(if $(shell bzr), , $(error $(BZR_ERROR)))
 
 get-code:
-	go get $(GO_EXTRAFLAGS) -u -d -t -v -x ./...
+	go get $(GO_EXTRAFLAGS) -u -d -t -insecure ./...
 
 godep:
 	go get $(GO_EXTRAFLAGS) github.com/tools/godep

--- a/api/api.go
+++ b/api/api.go
@@ -2,7 +2,7 @@ package api
 
 import (
 	"fmt"
-	"log"
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/kolo/xmlrpc"
 )
@@ -20,14 +20,17 @@ type Rpc struct {
  * Creates an RPCClient with endpoint and returns it
  *
  **/
-func NewRPCClient(endpoint string, username string, password string) (Rpc, error) {
+func NewRPCClient(endpoint string, username string, password string) (*Rpc, error) {
 	RPCclient, err := xmlrpc.NewClient(endpoint, nil)
+
 	if err != nil {
-		log.Fatal(err)
+		return nil, fmt.Errorf("unable to connect with one %q: %s", endpoint, err)
 	}
-	RpcObj := Rpc{RPCClient: *RPCclient, Key: username + ":" + password}
-	fmt.Println(RpcObj.Key)
-	return RpcObj, nil
+	log.Debugf("[one-go] -- client --- \ncommand: %s\nconnected: %s\n[one-go] --- client --- \n", endpoint)
+
+	return &Rpc{
+		RPCClient: *RPCclient,
+		Key:       username + ":" + password}, nil
 }
 
 /**
@@ -36,12 +39,12 @@ func NewRPCClient(endpoint string, username string, password string) (Rpc, error
  *
  **/
 func (c *Rpc) Call(RPC xmlrpc.Client, command string, args []interface{}) ([]interface{}, error) {
-
+	log.Debugf("[one-go] -- request --- \ncommand: %s\nargs: %s\n[one-go] --- request --- \n", command, args)
 	result := []interface{}{}
-	cerr := RPC.Call(command, args, &result)
-	if cerr != nil {
-		return nil, cerr
+	err := RPC.Call(command, args, &result)
+	if err != nil {
+		return nil, fmt.Errorf("one rpc execution %q failure: %s", command, err)
 	}
-
+	log.Debugf("[one-go] -- response --- \nresult: %s\n[one-go] --- request --- \n", result)
 	return result, nil
 }

--- a/compute/compute_test.go
+++ b/compute/compute_test.go
@@ -19,7 +19,7 @@ var _ = check.Suite(&S{})
 func (s *S) TestCreate(c *check.C) {
 	//oneadmin:yib4OquafUp1
 	client, _ := api.NewRPCClient("http://192.168.1.100:2633/RPC2", "oneadmin", "yib4OquafUp1")
-	vmObj := VirtualMachine{Name: "yeshapp_new_files", TemplateName: "yesh_trusty", Cpu: "1", Memory: "1024", Assembly_id: "ASM007", Client: &client} //memory in terms of MB! duh!
+	vmObj := VirtualMachine{Name: "yeshapp_new_files", TemplateName: "yesh_trusty", Cpu: "1", Memory: "1024", Assembly_id: "ASM007", Client: client} //memory in terms of MB! duh!
 
 	_, error := vmObj.Create()
 	c.Assert(error, check.IsNil)

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -20,7 +20,7 @@ var _ = check.Suite(&S{})
 
 func (s *S) TestGetTemplateByName(c *check.C) {
 	client, _ := api.NewRPCClient("http://localhost:2633/RPC2", "oneadmin", "RaifZuewjoc4")
-	flav := TemplateReqs{TemplateName: "newone", Client: &client}
+	flav := TemplateReqs{TemplateName: "newone", Client: client}
 	res, error := flav.GetTemplateByName()
 	fmt.Println(res[0].Id)
 	c.Assert(error, check.IsNil)
@@ -28,7 +28,7 @@ func (s *S) TestGetTemplateByName(c *check.C) {
 
 func (s *S) TestGetTemplate(c *check.C) {
 	client, _ := api.NewRPCClient("http://localhost:2633/RPC2", "oneadmin", "RaifZuewjoc4")
-	flav := TemplateReqs{TemplateId: 33, Client: &client}
+	flav := TemplateReqs{TemplateId: 33, Client: client}
 	_, error := flav.GetTemplate()
 	c.Assert(error, check.IsNil)
 }

--- a/virtualmachine/virtualmachine_test.go
+++ b/virtualmachine/virtualmachine_test.go
@@ -19,7 +19,7 @@ var _ = check.Suite(&S{})
 
 func (s *S) TestGetVirtualMachineByName(c *check.C) {
 	client, _ := api.NewRPCClient("http://localhost:2633/RPC2", "oneadmin", "RaifZuewjoc4")
-	vm := VirtualMachineReqs{VMName: "yeshapp", Client: &client}
+	vm := VirtualMachineReqs{VMName: "yeshapp", Client: client}
 	res, error := vm.GetVirtualMachineByName()
 	fmt.Println(res[0].Id)
 	c.Assert(error, check.IsNil)


### PR DESCRIPTION
#8  I only fixed the code the vm.`create` and vm.`delete`

@morpheyesh  Please crank `good` code with thinking beyond the library you write.

@rajthilakmca  Review it please, we need to build tighter code.