### PR TITLE
Add missing VmState constants for accounting

### DIFF
--- a/metrics/accounting.go
+++ b/metrics/accounting.go
@@ -37,6 +37,8 @@ const (
 	SUSPENDED
 	DONE
 	FAILED
+	POWEROFF
+	UNDEPLOYED
 
 	//LcmState starts at 0
 	LCM_INIT LcmState = iota


### PR DESCRIPTION
There are two more states that did not have constants for accounting.
These states are defined in the XMLRPC schema here...

http://docs.opennebula.org/4.12/integration/system_interfaces/api.html#schemas-for-virtual-machine

... and the VM lifecycle here...

http://docs.opennebula.org/4.12/user/virtual_resource_management/vm_guide_2.html